### PR TITLE
Predisの参照先を書き換え

### DIFF
--- a/Redis/README.md
+++ b/Redis/README.md
@@ -1,2 +1,7 @@
 # Redis
 Redisの学習まとめ
+
+## Docker
+```
+docker run -d -p 6379:6379 --name myredis redis
+```

--- a/Redis/code/composer.json
+++ b/Redis/code/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "predis/predis": "^1.1"
+    }
+}

--- a/Redis/code/composer.lock
+++ b/Redis/code/composer.lock
@@ -1,0 +1,68 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "80aa1bb66ab44973c6b98031709a4dbc",
+    "packages": [
+        {
+            "name": "predis/predis",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nrk/predis.git",
+                "reference": "f0210e38881631afeafb56ab43405a92cafd9fd1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nrk/predis/zipball/f0210e38881631afeafb56ab43405a92cafd9fd1",
+                "reference": "f0210e38881631afeafb56ab43405a92cafd9fd1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8"
+            },
+            "suggest": {
+                "ext-curl": "Allows access to Webdis when paired with phpiredis",
+                "ext-phpiredis": "Allows faster serialization and deserialization of the Redis protocol"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Predis\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniele Alessandri",
+                    "email": "suppakilla@gmail.com",
+                    "homepage": "http://clorophilla.net"
+                }
+            ],
+            "description": "Flexible and feature-complete Redis client for PHP and HHVM",
+            "homepage": "http://github.com/nrk/predis",
+            "keywords": [
+                "nosql",
+                "predis",
+                "redis"
+            ],
+            "time": "2016-06-16T16:22:20+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/Redis/code/redis_hash.php
+++ b/Redis/code/redis_hash.php
@@ -4,8 +4,9 @@
  *
  * @var Redis
  */
-$redis = new Redis();
-$redis->connect('127.0.0.1', 6379);
+require_once 'vendor/autoload.php';
+
+$redis = new Predis\Client();
 
 // 値をセット
 $redis->hSet('hash', 'hash1', 1);

--- a/Redis/code/redis_list.php
+++ b/Redis/code/redis_list.php
@@ -4,8 +4,9 @@
  *
  * @var Redis
  */
-$redis = new Redis();
-$redis->connect('127.0.0.1', 6379);
+require_once 'vendor/autoload.php';
+
+$redis = new Predis\Client();
 
 // lPushは先頭、rPushは末尾に値をpush
 $redis->rPush('name_list', 'c');

--- a/Redis/code/redis_set.php
+++ b/Redis/code/redis_set.php
@@ -4,8 +4,9 @@
  *
  * @var Redis
  */
-$redis = new Redis();
-$redis->connect('127.0.0.1', 6379);
+require_once 'vendor/autoload.php';
+
+$redis = new Predis\Client();
 
 // 値を追加
 $redis->sAdd('test1' , '1');

--- a/Redis/code/redis_sorted_Set.php
+++ b/Redis/code/redis_sorted_Set.php
@@ -4,8 +4,9 @@
  *
  * @var Redis
  */
-$redis = new Redis();
-$redis->connect('127.0.0.1', 6379);
+require_once 'vendor/autoload.php';
+
+$redis = new Predis\Client();
 
 // スコアと値を追加
 $redis->zAdd('science' , 50, 'test1');

--- a/Redis/code/redis_string.php
+++ b/Redis/code/redis_string.php
@@ -4,7 +4,8 @@
  *
  * @var Redis
  */
-$redis = new Redis();
-$redis->connect('127.0.0.1', 6379);
+require_once 'vendor/autoload.php';
+
+$redis = new Predis\Client();
 $redis->set('name', 'taro');
 echo $redis->get('name');


### PR DESCRIPTION
## 背景
最近Predisを触ったら、Composerからインストールできるようになっていた。
そのため、既存コードをComposerからアクセスするように修正。